### PR TITLE
Prefer classes dir for hot deployment of static resources

### DIFF
--- a/.github/ISSUE_TEMPLATE/ecosystem-ci-participant-issue.md
+++ b/.github/ISSUE_TEMPLATE/ecosystem-ci-participant-issue.md
@@ -7,6 +7,6 @@ assignees: ''
 
 ---
 
-This issue will be open and closed dependent on the state of <particpant repo url> building against Quarkus master snapshot.
+This issue will be open and closed dependent on the state of <participant repo url> building against Quarkus main snapshot.
 
 If you have interest in being notified of this subscribe to the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,9 @@ assignees: ''
 ---
 
 ## Description
+
 (Describe the feature here.)
 
 ## Implementation ideas
-(If you have any implementation ideas, they can go here, however please note that all design change proposals should be posted to [the Quarkus developer mailing list](mailto:quarkus-dev@googlegroups.com) (or [the corresponding Google Group](https://groups.google.com/group/quarkus-dev); see [the decisions process document](https://github.com/quarkusio/quarkus/blob/master/DECISIONS.adoc) for more information).
+
+(If you have any implementation ideas, they can go here, however please note that all design change proposals should be posted to [the Quarkus developer mailing list](mailto:quarkus-dev@googlegroups.com) (or [the corresponding Google Group](https://groups.google.com/group/quarkus-dev); see [the decisions process document](https://github.com/quarkusio/quarkus/blob/main/DECISIONS.adoc) for more information).

--- a/.github/quarkus-bot-java.yml
+++ b/.github/quarkus-bot-java.yml
@@ -1,6 +1,6 @@
 ---
 # The format of this file is documented here:
-# https://github.com/quarkusio/quarkus-bot-java#triage-issues
+# https://github.com/quarkusio/quarkus-bot#triage-issues
 triage:
   rules:
     - labels: [area/amazon-lambda]

--- a/.github/quarkus-bot.yml
+++ b/.github/quarkus-bot.yml
@@ -1,6 +1,6 @@
 ---
 # The format of this file is documented here:
-# https://github.com/quarkusio/quarkus-bot/#triage-issues
+# https://github.com/quarkusio/quarkus-bot#triage-issues
 triage:
   rules:
     - labels: [area/amazon-lambda]
@@ -52,16 +52,16 @@ triage:
         - devtools/platform-descriptor-json/src/main/resources/codestarts/
         - devtools/platform-descriptor-json/src/main/resources/templates/
     - labels: [area/hibernate-reactive, area/persistence]
-      title: "hibernate reactive"
+      title: "hibernate.reactive"
       notify: [DavideD, gavinking, Sanne]
       directories:
         - extensions/hibernate-reactive
     - labels: [area/hibernate-orm, area/persistence]
       expression: |
-              title.match(/hibernate/i)
-              && !title.match(/hibernate.validator/i)
-              && !title.match(/hibernate.search/i)
-              && !title.match(/hibernate.reactive/i)
+              matches("hibernate", title)
+              && !matches("hibernate.validator", title)
+              && !matches("hibernate.search", title)
+              && !matches("hibernate.reactive", title)
       notify: [gsmet, Sanne, yrodiere]
       directories:
         - extensions/hibernate-orm/
@@ -76,7 +76,7 @@ triage:
         - integration-tests/jpa/
         - integration-tests/infinispan-cache-jpa/
     - labels: [area/hibernate-search]
-      title: hibernate search
+      title: "hibernate.search"
       notify: [gsmet, yrodiere]
       directories:
         - extensions/hibernate-search-orm-elasticsearch/
@@ -84,19 +84,19 @@ triage:
         - extensions/elasticsearch-rest-client/
         - extensions/elasticsearch-rest-client-common/
     - labels: [area/elasticsearch]
-      title: elasticsearch
+      title: "elasticsearch"
       notify: [gsmet, yrodiere, loicmathieu]
       directories:
         - extensions/elasticsearch
         - integration-tests/elasticsearch
     - labels: [area/hibernate-validator]
-      title: hibernate validator
+      title: "hibernate.validator"
       notify: [gsmet, yrodiere]
       directories:
         - extensions/hibernate-validator/
         - integration-tests/hibernate-validator/
     - labels: [area/jaeger]
-      title: jaeger
+      title: "jaeger"
       notify: [kenfinnigan]
       directories:
         - extensions/jaeger/
@@ -107,7 +107,7 @@ triage:
         - extensions/kotlin/
         - integration-tests/kotlin/
     - labels: [area/mongodb]
-      title: mongo
+      title: "mongo"
       notify: [loicmathieu, evanchooly]
       directories:
         - extensions/mongodb-client/
@@ -115,12 +115,12 @@ triage:
         - integration-tests/mongodb-panache/
         - extensions/panache/mongodb-panache/
     - labels: [area/openapi, area/smallrye]
-      title: openapi
+      title: "openapi"
       notify: [EricWittmann, MikeEdgar, phillip-kruger]
       directories:
         - extensions/smallrye-openapi
     - labels: [area/graphql, area/smallrye]
-      title: graphql
+      title: "graphql"
       notify: [phillip-kruger, jmartisk]
       directories:
         - extensions/smallrye-graphql/
@@ -222,6 +222,7 @@ triage:
       notify: [geoand]
     - labels: [area/kafka]
       notify: [cescoffier]
+      title: "kafka"
       directories:
         - extensions/kafka-client/
         - integration-tests/kafka/
@@ -256,7 +257,7 @@ triage:
         - extensions/quartz/
         - integration-tests/quartz/
     - labels: [area/redis]
-      title: redis
+      title: "redis"
       notify: [machi1990, gsmet, cescoffier]
       directories:
         - extensions/redis-client/
@@ -274,7 +275,7 @@ triage:
         - extensions/google-cloud-functions
         - integration-tests/google-cloud-functions
     - labels: [area/mandrel]
-      titleBody: mandrel
+      titleBody: "mandrel"
       notify: [galderz, zakkak]
     - labels: [area/artemis]
       directories:
@@ -283,7 +284,7 @@ triage:
         - integration-tests/artemis-core/
         - integration-tests/artemis-jms/
     - labels: [area/cache]
-      title: cache
+      title: "cache"
       notify: [gwenneg]
       directories:
         - extensions/cache/
@@ -316,7 +317,7 @@ triage:
       directories:
         - .github/
     - labels: [area/jaxb]
-      title: jaxb
+      title: "jaxb"
       notify: [gsmet]
       directories:
         - extensions/jaxb/
@@ -335,13 +336,13 @@ triage:
         - integration-tests/narayana-jta/
         - integration-tests/narayana-stm/
     - labels: [area/neo4j]
-      title: neo4j
+      title: "neo4j"
       notify: [michael-simons]
       directories:
         - extensions/neo4j/
         - integration-tests/neo4j/
     - labels: [area/oidc]
-      title: oidc
+      title: "oidc"
       notify: [sberyozkin, pedroigor]
       directories:
         - extensions/oidc/
@@ -405,7 +406,7 @@ triage:
       directories:
         - extensions/websockets/
     - labels: [area/swagger-ui]
-      title: swagger
+      title: "swagger"
       notify: [phillip-kruger]
       directories:
         - extensions/swagger-ui/
@@ -416,13 +417,13 @@ triage:
         - extensions/vertx-keycloak/
         - integration-tests/elytron
     - labels: [area/flyway]
-      title: flyway
+      title: "flyway"
       notify: [cristhiank, geoand, gastaldi, gsmet]
       directories:
         - extensions/flyway/
         - integration-tests/flyway/
     - labels: [area/liquibase]
-      title: liquibase
+      title: "liquibase"
       notify: [andrejpetras, geoand, gsmet]
       directories:
         - extensions/liquibase/

--- a/.github/quarkusbuilditemdoc.java
+++ b/.github/quarkusbuilditemdoc.java
@@ -176,7 +176,7 @@ class quarkusbuilditemdoc implements Callable<Integer> {
     private void printTableRow(Pair<Path, JavaClassSource> pair) {
         //TODO: Use tagged version?
         Path root = Paths.get(".").toAbsolutePath().normalize();
-        String link = "https://github.com/quarkusio/quarkus/blob/master/" + root.relativize(pair.getOne().normalize());
+        String link = "https://github.com/quarkusio/quarkus/blob/main/" + root.relativize(pair.getOne().normalize());
         JavaClassSource source = pair.getTwo();
         String className = source.getQualifiedName();
         String attributes = buildAttributes(source);

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -43,17 +43,17 @@ jobs:
   ci-sanity-check:
     name: "CI Sanity Check"
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     steps:
       - name: Build
         run: sleep 30
   build-jdk11:
     name: "Initial JDK 11 Build"
     runs-on: ubuntu-latest
-    # Skip master in forks
+    # Skip main in forks
     # Skip draft PRs and those with WIP in the subject, rerun as soon as its removed
-    if: "(github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')) && ( \
+    if: "(github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')) && ( \
            github.event_name != 'pull_request' || ( \
              github.event.pull_request.draft == false && \
              github.event.pull_request.state != 'closed' && \
@@ -131,10 +131,10 @@ jobs:
               # - the current branch is a backport branch
               GIB_ARGS+=" -Dgib.referenceBranch=origin/$PULL_REQUEST_BASE -Dgib.disableIfBranchRegex='.*backport.*'"
           else
-              # No PR means the merge target is uncertain so fetch & use master of quarkusio/quarkus, *unless*:
-              # - the current branch is master or some released branch like 1.10
-              # - the current branch is a backport branch targeting some released branch like 1.10 (merge target is not master)
-              GIB_ARGS+=" -Dgib.referenceBranch=refs/remotes/quarkusio/master -Dgib.fetchReferenceBranch -Dgib.disableIfBranchRegex='master|\d+\.\d+|.*backport.*'"
+              # No PR means the merge target is uncertain so fetch & use main of quarkusio/quarkus, *unless*:
+              # - the current branch is main or some released branch like 1.10
+              # - the current branch is a backport branch targeting some released branch like 1.10 (merge target is not main)
+              GIB_ARGS+=" -Dgib.referenceBranch=refs/remotes/quarkusio/main -Dgib.fetchReferenceBranch -Dgib.disableIfBranchRegex='main|\d+\.\d+|.*backport.*'"
           fi
           echo "GIB_ARGS: $GIB_ARGS"
           echo "::set-output name=gib_args::${GIB_ARGS}"
@@ -144,8 +144,8 @@ jobs:
   linux-jvm-tests:
     name: JVM Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 240
     env:
@@ -223,8 +223,8 @@ jobs:
   windows-jdk11-jvm-tests:
     name: JVM Tests - JDK 11 Windows
     runs-on: windows-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 180
     env:
@@ -269,8 +269,8 @@ jobs:
   linux-jvm-maven-tests:
     name: Maven Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 60
     strategy:
@@ -317,8 +317,8 @@ jobs:
   windows-jdk11-jvm-maven-tests:
     name: Maven Tests - JDK 11 Windows
     runs-on: windows-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 60
     strategy:
@@ -360,8 +360,8 @@ jobs:
   linux-jvm-gradle-tests:
     name: Gradle Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 60
     strategy:
@@ -400,8 +400,8 @@ jobs:
   windows-jdk11-jvm-gradle-tests:
     name: Gradle Tests - JDK 11 Windows
     needs: build-jdk11
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     runs-on: windows-latest
     timeout-minutes: 80
     steps:
@@ -433,8 +433,8 @@ jobs:
   linux-jvm-devtools-tests:
     name: Devtools Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 60
     strategy:
@@ -481,8 +481,8 @@ jobs:
   windows-jdk11-jvm-devtools-tests:
     name: Devtools Tests - JDK 11 Windows
     runs-on: windows-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 60
     strategy:
@@ -524,8 +524,8 @@ jobs:
   tcks-test:
     name: MicroProfile TCKs Tests
     needs: build-jdk11
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     runs-on: ubuntu-latest
     timeout-minutes: 150
 
@@ -580,8 +580,8 @@ jobs:
   native-tests-read-json-matrix:
     name: Native Tests - Read JSON matrix
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     outputs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:
@@ -596,8 +596,8 @@ jobs:
     name: Native Tests - ${{matrix.category}}
     needs: [build-jdk11, native-tests-read-json-matrix]
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:
@@ -659,8 +659,8 @@ jobs:
     name: Native Tests - Windows - ${{matrix.category}}
     needs: [build-jdk11, native-tests-read-json-matrix]
     runs-on: windows-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:

--- a/.github/workflows/ci-actions.yml.disabled
+++ b/.github/workflows/ci-actions.yml.disabled
@@ -42,17 +42,17 @@ jobs:
   ci-sanity-check:
     name: "CI Sanity Check"
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     steps:
       - name: Build
         run: sleep 30
   build-jdk11:
     name: "Initial JDK 11 Build"
     runs-on: ubuntu-latest
-    # Skip master in forks
+    # Skip main in forks
     # Skip draft PRs and those with WIP in the subject, rerun as soon as its removed
-    if: "(github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')) && ( \
+    if: "(github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')) && ( \
            github.event_name != 'pull_request' || ( \
              github.event.pull_request.draft == false && \
              github.event.pull_request.state != 'closed' && \
@@ -116,8 +116,8 @@ jobs:
   linux-jvm-tests:
     name: JVM Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 240
     env:
@@ -188,8 +188,8 @@ jobs:
   windows-jdk11-jvm-tests:
     name: JVM Tests - JDK 11 Windows
     runs-on: windows-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 180
     env:
@@ -229,8 +229,8 @@ jobs:
   linux-jvm-maven-tests:
     name: Maven Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 60
     strategy:
@@ -272,8 +272,8 @@ jobs:
   windows-jdk11-jvm-maven-tests:
     name: Maven Tests - JDK 11 Windows
     runs-on: windows-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 60
     strategy:
@@ -310,8 +310,8 @@ jobs:
   linux-jvm-gradle-tests:
     name: Gradle Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 60
     strategy:
@@ -350,8 +350,8 @@ jobs:
   windows-jdk11-jvm-gradle-tests:
     name: Gradle Tests - JDK 11 Windows
     needs: build-jdk11
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     runs-on: windows-latest
     timeout-minutes: 80
     steps:
@@ -383,8 +383,8 @@ jobs:
   linux-jvm-devtools-tests:
     name: Devtools Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 60
     strategy:
@@ -426,8 +426,8 @@ jobs:
   windows-jdk11-jvm-devtools-tests:
     name: Devtools Tests - JDK 11 Windows
     runs-on: windows-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
     timeout-minutes: 60
     strategy:
@@ -464,8 +464,8 @@ jobs:
   tcks-test:
     name: MicroProfile TCKs Tests
     needs: build-jdk11
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     runs-on: ubuntu-latest
     timeout-minutes: 150
 
@@ -514,8 +514,8 @@ jobs:
   native-tests-read-json-matrix:
     name: Native Tests - Read JSON matrix
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     outputs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:
@@ -530,8 +530,8 @@ jobs:
     name: Native Tests - ${{matrix.category}}
     needs: [build-jdk11, native-tests-read-json-matrix]
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:

--- a/.github/workflows/ci-fork-mvn-cache.yml
+++ b/.github/workflows/ci-fork-mvn-cache.yml
@@ -3,7 +3,7 @@ name: Quarkus CI Fork Maven Cache
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     # paths-ignore should match ci-actions.yml
     paths-ignore:
       - '.gitignore'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v2
       with:
           fetch-depth: 1
-          ref: master
+          ref: main
     - name: Setup Java JDK
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Set up JDK 8

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -21,8 +21,8 @@ jobs:
   build-doc:
     name: "Documentation Build"
     runs-on: ubuntu-latest
-    # Skip master in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/master')"
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     steps:
       - uses: actions/checkout@v2
       - uses: n1hility/cancel-previous-runs@v2

--- a/.github/workflows/native-cron-build.yml.disabled
+++ b/.github/workflows/native-cron-build.yml.disabled
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: quarkusio/quarkus
-          ref: master
+          ref: main
 
       - uses: actions/cache@v1
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Set up JDK 8

--- a/.github/workflows/sonarcloud.yml.disabled
+++ b/.github/workflows/sonarcloud.yml.disabled
@@ -2,7 +2,7 @@ name: Sonarcloud Analysis
 #on:
 #  push:
 #    branches:
-#      - master
+#      - main
 #  pull_request:
 #    types: [opened, synchronize, reopened]
 jobs:

--- a/COMMITTERS.adoc
+++ b/COMMITTERS.adoc
@@ -45,7 +45,7 @@ While not absolute, here is some advice:
 * Make sure the commit comments are meaningful.
 * As a new committer, you can start by giving your approval and not merging and see how things evolve.
   This should give you some hints of important things to check in the future.
-* Only merge pull requests that target master.
+* Only merge pull requests that target main.
   **Dealing with old branches is a separate process.**
 * If you are sure a PR should go in and is just waiting for CI,
   just use the `triage/waiting-for-ci` label.
@@ -90,13 +90,13 @@ In short, posting a large PR the day before the release won't work.
 
 Quarkus depends on a lot of third party dependencies that we try to keep up to date.
 
-We partially rely on Dependabot for https://github.com/quarkusio/quarkus/blob/master/.github/dependabot.yml[a curated list of dependencies].
+We partially rely on Dependabot for https://github.com/quarkusio/quarkus/blob/main/.github/dependabot.yml[a curated list of dependencies].
 
 Some dependencies are critical for Quarkus and quite complex.
 Good examples would be Vert.x or Hibernate ORM.
 
 It is good practice to update these core dependencies at the beginning of a given
-release cycle to let them time to bake in the master branch before being released.
+release cycle to let them time to bake in the main branch before being released.
 
 == Backward Compatibility
 
@@ -198,7 +198,7 @@ release a couple of weeks after.
 Every time we do a major release (e.g. `1.7.0.Final`), we create a release branch (e.g. `1.7`) to host
 the commits for these bugfix releases.
 
-All the pull requests are merged in the `master` branch so they are applied to the new feature 
+All the pull requests are merged in the `main` branch so they are applied to the new feature 
 release of Quarkus.
 They won't be integrated in the previous version branch.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@ But first, read this page (including the small print at the end).
 
 * [Legal](#legal)
 * [Reporting an issue](#reporting-an-issue)
-* [Checking an issue is fixed in master](#checking-an-issue-is-fixed-in-master)
+* [Checking an issue is fixed in main](#checking-an-issue-is-fixed-in-main)
   + [Using snapshots](#using-snapshots)
-  + [Building master](#building-master)
+  + [Building main](#building-main)
   + [Updating the version](#updating-the-version)
 * [Before you contribute](#before-you-contribute)
   + [Code reviews](#code-reviews)
@@ -58,15 +58,15 @@ This project uses GitHub issues to manage the issues. Open an issue directly in 
 If you believe you found a bug, and it's likely possible, please indicate a way to reproduce it, what you are seeing and what you would expect to see.
 Don't forget to indicate your Quarkus, Java, Maven/Gradle and GraalVM version. 
 
-## Checking an issue is fixed in master
+## Checking an issue is fixed in main
 
-Sometimes a bug has been fixed in the `master` branch of Quarkus and you want to confirm it is fixed for your own application.
-Testing the `master` branch is easy and you have two options:
+Sometimes a bug has been fixed in the `main` branch of Quarkus and you want to confirm it is fixed for your own application.
+Testing the `main` branch is easy and you have two options:
 
 * either use the snapshots we publish daily on https://oss.sonatype.org/content/repositories/snapshots/
 * or build Quarkus all by yourself
 
-This is a quick summary to get you to quickly test master.
+This is a quick summary to get you to quickly test main.
 If you are interested in having more details, refer to the [Build section](#build) and the [Usage section](#usage).
 
 ### Using snapshots
@@ -77,7 +77,7 @@ Then just add https://oss.sonatype.org/content/repositories/snapshots/ as a Mave
 
 You can check the last publication date here: https://oss.sonatype.org/content/repositories/snapshots/io/quarkus/ .
 
-### Building master
+### Building main
 
 Just do the following:
 
@@ -92,7 +92,7 @@ Wait for a bit and you're done.
 
 ### Updating the version
 
-Be careful, when using the `master` branch, you need to use the `quarkus-bom` instead of the `quarkus-universe-bom`.
+Be careful, when using the `main` branch, you need to use the `quarkus-bom` instead of the `quarkus-universe-bom`.
 
 Update both the versions of the `quarkus-bom` and the Quarkus Maven plugin to `999-SNAPSHOT`.
 
@@ -129,7 +129,7 @@ Because we are all humans, and to ensure Quarkus is stable for everyone, all cha
 
 The process requires only one additional step to enable Actions on your fork (clicking the green button in the actions tab). [See the full video walkthrough](https://youtu.be/egqbx-Q-Cbg) for more details on how to do this.
 
-To keep the caching of non-Quarkus artifacts efficient (speeding up CI), you should occasionally sync the `master` branch of your fork with `master` of this repo (e.g. monthly).
+To keep the caching of non-Quarkus artifacts efficient (speeding up CI), you should occasionally sync the `main` branch of your fork with `main` of this repo (e.g. monthly).
 
 ### Tests and documentation are not optional
 
@@ -282,7 +282,7 @@ In this command we use the groupId and artifactId of the module to identify it.
 
 #### Running a single test
 
-Often you need to run a single test from some Maven module. Say for example you want to run the `GreetingResourceTest` of the `resteasy-jackson` Quarkus integration test (which can be found [here](https://github.com/quarkusio/quarkus/blob/master/integration-tests/resteasy-jackson)).
+Often you need to run a single test from some Maven module. Say for example you want to run the `GreetingResourceTest` of the `resteasy-jackson` Quarkus integration test (which can be found [here](https://github.com/quarkusio/quarkus/blob/main/integration-tests/resteasy-jackson)).
 One way to accomplish this is by executing the following command:
 
 ```
@@ -298,7 +298,7 @@ E.g.:
 ```
 ./mvnw install -Dincremental
 ```
-This will build all modules (and their downstream modules) that have been changed compared to your _local_ `master`, including untracked and uncommitted changes.
+This will build all modules (and their downstream modules) that have been changed compared to your _local_ `main`, including untracked and uncommitted changes.
 
 If you just want to build the changes since the last commit on the current branch, you can switch off the branch comparison via `-Dgib.disableBranchComparison` (or short: `-Dgib.dbc`).
 
@@ -322,7 +322,7 @@ CI is using a slighty different GIB config than locally:
 * [Special handling of "Explicitly selected projects"](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder#explicitly-selected-projects) is deactivated
 * Untracked/uncommitted changes are not considered
 * Branch comparison is more complex due to distributed GitHub forks
-* Certain "critical" branches like `master` are not built incrementally
+* Certain "critical" branches like `main` are not built incrementally
 
 For more details see the `Get GIB arguments` step in `.github/workflows/ci-actions-incremental.yml`.
 

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -173,7 +173,7 @@
         <sentry.version>4.3.0</sentry.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.1.1</kubernetes-client.version>
+        <kubernetes-client.version>5.2.0</kubernetes-client.version>
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -148,7 +148,7 @@
         <aws-lambda-java-events.version>3.7.0</aws-lambda-java-events.version>
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
         <aws-xray.version>2.8.0</aws-xray.version>
-        <awssdk.version>2.16.17</awssdk.version>
+        <awssdk.version>2.16.18</awssdk.version>
         <aws-alexa-sdk.version>2.37.1</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.4.0</azure-functions-java-library.version>
         <kotlin.version>1.4.31</kotlin.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3211,7 +3211,7 @@
                 <version>${jakarta.interceptor-api.version}</version>
                 <exclusions>
                     <!-- There is a bug in 1.2.5 -->
-                    <!-- The dependency is removed in master: https://github.com/eclipse-ee4j/interceptor-api/commit/017aeb56849bbb448319aaf36df45a07ec54f451 -->
+                    <!-- The dependency is removed in main: https://github.com/eclipse-ee4j/interceptor-api/commit/017aeb56849bbb448319aaf36df45a07ec54f451 -->
                     <exclusion>
                         <groupId>jakarta.ejb</groupId>
                         <artifactId>jakarta.ejb-api</artifactId>

--- a/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
@@ -155,7 +155,7 @@ public final class BuildChainBuilder {
         int initialSingleCount = 0;
         int initialMultiCount = 0;
         final Map<BuildStepBuilder, StackTraceElement[]> steps = this.steps;
-        // compile master produce/consume maps
+        // compile main produce/consume maps
         final Map<ItemId, List<Consume>> allConsumes = new HashMap<>();
         final Map<ItemId, List<Produce>> allProduces = new HashMap<>();
         final Set<ItemId> initialIds = this.initialIds;

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -118,7 +118,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     public Path getClassesDir() {
         //TODO: fix all these
         for (DevModeContext.ModuleInfo i : context.getAllModules()) {
-            return Paths.get(i.getResourcePath());
+            return Paths.get(i.getClassesPath());
         }
         return null;
     }

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionLegacyMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionLegacyMojo.java
@@ -412,7 +412,7 @@ public class CreateExtensionLegacyMojo extends AbstractMojo {
      * Note that you do not need to provide all of them. Files not available in your custom {@link #templatesUriBase}
      * will be looked up in the default URI base {@value #DEFAULT_TEMPLATES_URI_BASE}. The default templates are
      * maintained <a href=
-     * "https://github.com/quarkusio/quarkus/tree/master/devtools/maven/src/main/resources/create-extension-templates">here</a>.
+     * "https://github.com/quarkusio/quarkus/tree/main/devtools/maven/src/main/resources/create-extension-templates">here</a>.
      *
      * @since 0.20.0
      */

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/github-action/base/.github/workflows/ci.tpl.qute.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/github-action/base/.github/workflows/ci.tpl.qute.yml
@@ -4,9 +4,9 @@ name: Quarkus Codestart CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2562,12 +2562,12 @@
                         <quarkus-base-url>${quarkus-base-url}</quarkus-base-url>
                         <!-- Quarkus repository URL to clone -->
                         <quarkus-clone-url>${quarkus-base-url}.git</quarkus-clone-url>
-                        <!-- Quarkus URL to master source archive -->
-                        <quarkus-archive-url>${quarkus-base-url}/archive/master.zip</quarkus-archive-url>
-                        <!-- Quarkus URL to master blob source tree; used for referencing source files -->
-                        <quarkus-blob-url>${quarkus-base-url}/blob/master</quarkus-blob-url>
-                        <!-- Quarkus URL to master source tree root; used for referencing directories -->
-                        <quarkus-tree-url>${quarkus-base-url}/tree/master</quarkus-tree-url>
+                        <!-- Quarkus URL to main source archive -->
+                        <quarkus-archive-url>${quarkus-base-url}/archive/main.zip</quarkus-archive-url>
+                        <!-- Quarkus URL to main blob source tree; used for referencing source files -->
+                        <quarkus-blob-url>${quarkus-base-url}/blob/main</quarkus-blob-url>
+                        <!-- Quarkus URL to main source tree root; used for referencing directories -->
+                        <quarkus-tree-url>${quarkus-base-url}/tree/main</quarkus-tree-url>
                         <!-- Quarkus URL to issues -->
                         <quarkus-issues-url>${quarkus-base-url}/issues</quarkus-issues-url>
                         <quarkus-images-url>https://github.com/quarkusio/quarkus-images/tree</quarkus-images-url>
@@ -2577,12 +2577,12 @@
                         <quickstarts-base-url>${quickstarts-base-url}</quickstarts-base-url>
                         <!-- Quickstart repository URL to clone -->
                         <quickstarts-clone-url>${quickstarts-base-url}.git</quickstarts-clone-url>
-                        <!-- Quickstart URL to master source archive -->
-                        <quickstarts-archive-url>${quickstarts-base-url}/archive/master.zip</quickstarts-archive-url>
-                        <!-- Quickstart URL to master blob source tree; used for referencing source files -->
-                        <quickstarts-blob-url>${quickstarts-base-url}/blob/master</quickstarts-blob-url>
-                        <!-- Quickstart URL to master source tree root; used for referencing directories -->
-                        <quickstarts-tree-url>${quickstarts-base-url}/tree/master</quickstarts-tree-url>
+                        <!-- Quickstart URL to main source archive -->
+                        <quickstarts-archive-url>${quickstarts-base-url}/archive/main.zip</quickstarts-archive-url>
+                        <!-- Quickstart URL to main blob source tree; used for referencing source files -->
+                        <quickstarts-blob-url>${quickstarts-base-url}/blob/main</quickstarts-blob-url>
+                        <!-- Quickstart URL to main source tree root; used for referencing directories -->
+                        <quickstarts-tree-url>${quickstarts-base-url}/tree/main</quickstarts-tree-url>
                     </attributes>
                 </configuration>
                 <executions>

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -28,9 +28,9 @@ complete list of externalized variables for use is given in the following table:
 |\{quarkus-org-url}|{quarkus-org-url}| The location of the project github organization.
 |\{quarkus-base-url}|{quarkus-base-url}| Quarkus GitHub URL common base prefix.
 |\{quarkus-clone-url}|{quarkus-clone-url}| Quarkus URL for git clone referenced by the documentation.
-|\{quarkus-archive-url}|{quarkus-archive-url}| Quarkus URL to master source archive.
-|\{quarkus-blob-url}|{quarkus-blob-url}| Quarkus URL to master blob source tree; used for referencing source files.
-|\{quarkus-tree-url}|{quarkus-tree-url}| Quarkus URL to master source tree root; used for referencing directories.
+|\{quarkus-archive-url}|{quarkus-archive-url}| Quarkus URL to main source archive.
+|\{quarkus-blob-url}|{quarkus-blob-url}| Quarkus URL to main blob source tree; used for referencing source files.
+|\{quarkus-tree-url}|{quarkus-tree-url}| Quarkus URL to main source tree root; used for referencing directories.
 |\{quarkus-issues-url}|{quarkus-issues-url}| Quarkus URL to the issues page.
 |\{quarkus-images-url}|{quarkus-images-url}| Quarkus URL to set of container images delivered for Quarkus.
 
@@ -40,9 +40,9 @@ complete list of externalized variables for use is given in the following table:
 
 |\{quickstarts-base-url}|{quickstarts-base-url}| Quickstarts URL common base prefix.
 |\{quickstarts-clone-url}|{quickstarts-clone-url}| Quickstarts URL for git clone referenced by the documentation.
-|\{quickstarts-archive-url}|{quickstarts-archive-url}| Quickstarts URL to master source archive.
-|\{quickstarts-blob-url}|{quickstarts-blob-url}| Quickstarts URL to master blob source tree; used for referencing source files.
-|\{quickstarts-tree-url}|{quickstarts-tree-url}| Quickstarts URL to master source tree root; used for referencing directories.
+|\{quickstarts-archive-url}|{quickstarts-archive-url}| Quickstarts URL to main source archive.
+|\{quickstarts-blob-url}|{quickstarts-blob-url}| Quickstarts URL to main blob source tree; used for referencing source files.
+|\{quickstarts-tree-url}|{quickstarts-tree-url}| Quickstarts URL to main source tree root; used for referencing directories.
 
 |\{graalvm-version}|{graalvm-version}| Recommended GraalVM version to use.
 |\{graalvm-flavor}|{graalvm-flavor}| The full flavor of GraaVM to use e.g. `19.3.1-java11`. Make sure to use a `java11` version.

--- a/docs/src/main/asciidoc/all-builditems.adoc
+++ b/docs/src/main/asciidoc/all-builditems.adoc
@@ -4,7 +4,7 @@ layout: guides-configuration-reference
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 include::./attributes.adoc[]
 

--- a/docs/src/main/asciidoc/all-config.adoc
+++ b/docs/src/main/asciidoc/all-config.adoc
@@ -4,7 +4,7 @@ layout: guides-configuration-reference
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - All configuration options
 

--- a/docs/src/main/asciidoc/amazon-dynamodb.adoc
+++ b/docs/src/main/asciidoc/amazon-dynamodb.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon DynamoDB Client
 :extension-status: preview

--- a/docs/src/main/asciidoc/amazon-iam.adoc
+++ b/docs/src/main/asciidoc/amazon-iam.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon IAM Client
 :extension-status: preview

--- a/docs/src/main/asciidoc/amazon-kms.adoc
+++ b/docs/src/main/asciidoc/amazon-kms.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon KMS Client
 :extension-status: preview

--- a/docs/src/main/asciidoc/amazon-lambda-http.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon Lambda with RESTEasy, Undertow, or Vert.x Web
 :extension-status: preview

--- a/docs/src/main/asciidoc/amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon Lambda
 :extension-status: preview

--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon S3 Client
 

--- a/docs/src/main/asciidoc/amazon-ses.adoc
+++ b/docs/src/main/asciidoc/amazon-ses.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon SES Client
 :extension-status: preview

--- a/docs/src/main/asciidoc/amazon-sns.adoc
+++ b/docs/src/main/asciidoc/amazon-sns.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon SNS Client
 :extension-status: preview

--- a/docs/src/main/asciidoc/amazon-sqs.adoc
+++ b/docs/src/main/asciidoc/amazon-sqs.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon SQS Client
 :extension-status: preview

--- a/docs/src/main/asciidoc/amqp.adoc
+++ b/docs/src/main/asciidoc/amqp.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using AMQP with Reactive Messaging
 :extension-status: preview

--- a/docs/src/main/asciidoc/azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/azure-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Azure Functions (Serverless) with RESTEasy, Undertow, or Vert.x Web
 :extension-status: preview

--- a/docs/src/main/asciidoc/blaze-persistence.adoc
+++ b/docs/src/main/asciidoc/blaze-persistence.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Blaze-Persistence
 

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building my first extension
 

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building a Native Executable
 
@@ -45,7 +45,7 @@ If you are building native executables for macOS or Windows target platforms,
 you should consider using Oracle GraalVM instead,
 because Mandrel does not currently target these platforms.
 Building native executables directly on bare metal Linux is possible,
-with details available in the https://github.com/graalvm/mandrel/blob/master/README-Mandrel.md[Mandrel README]
+with details available in the https://github.com/graalvm/mandrel/blob/default/README.md[Mandrel README]
 and https://github.com/graalvm/mandrel/releases[Mandrel releases].
 
 The prerequisites vary slightly depending on whether you are using Oracle GraalVM CE/EE or Mandrel.

--- a/docs/src/main/asciidoc/building-substrate-howto.adoc
+++ b/docs/src/main/asciidoc/building-substrate-howto.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building a Custom SubstrateVM
 

--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Application Data Caching
 :extension-status: preview

--- a/docs/src/main/asciidoc/camel.adoc
+++ b/docs/src/main/asciidoc/camel.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Apache Camel on Quarkus
 

--- a/docs/src/main/asciidoc/cassandra.adoc
+++ b/docs/src/main/asciidoc/cassandra.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the Cassandra Client
 

--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - CDI Integration Guide
 

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Contexts and Dependency Injection
 

--- a/docs/src/main/asciidoc/cdi.adoc
+++ b/docs/src/main/asciidoc/cdi.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Introduction to Contexts and Dependency Injection
 

--- a/docs/src/main/asciidoc/centralized-log-management.adoc
+++ b/docs/src/main/asciidoc/centralized-log-management.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Centralized log management (Graylog, Logstash, Fluentd)
 

--- a/docs/src/main/asciidoc/class-loading-reference.adoc
+++ b/docs/src/main/asciidoc/class-loading-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Class Loading Reference
 

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building Quarkus apps with Quarkus Command Line Interface (CLI)
 

--- a/docs/src/main/asciidoc/command-mode-reference.adoc
+++ b/docs/src/main/asciidoc/command-mode-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Command Mode Applications
 

--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Configuration Reference Guide
 

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Configuring Your Application
 

--- a/docs/src/main/asciidoc/consul-config.adoc
+++ b/docs/src/main/asciidoc/consul-config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Reading properties from Consul
 

--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Container Images
 

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Context Propagation in Quarkus
 

--- a/docs/src/main/asciidoc/credentials-provider.adoc
+++ b/docs/src/main/asciidoc/credentials-provider.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using a Credentials Provider
 

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Datasources
 

--- a/docs/src/main/asciidoc/deploying-to-azure-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-azure-cloud.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Deploying to Microsoft Azure Cloud
 

--- a/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Deploying to Google Cloud Platform (GCP)
 

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Kubernetes extension
 

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Deploying on OpenShift
 

--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Dev UI
 

--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Connecting to an Elasticsearch cluster
 include::./attributes.adoc[]

--- a/docs/src/main/asciidoc/flyway.adoc
+++ b/docs/src/main/asciidoc/flyway.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Flyway
 

--- a/docs/src/main/asciidoc/funqy-amazon-lambda-http.adoc
+++ b/docs/src/main/asciidoc/funqy-amazon-lambda-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding with Amazon Lambda 
 :extension-status: preview

--- a/docs/src/main/asciidoc/funqy-amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/funqy-amazon-lambda.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy Amazon Lambda Binding
 :extension-status: preview

--- a/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding with Azure Functions
 :extension-status: preview

--- a/docs/src/main/asciidoc/funqy-gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding with Google Cloud Functions
 :extension-status: experimental

--- a/docs/src/main/asciidoc/funqy-gcp-functions.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy Google Cloud Functions
 :extension-status: experimental

--- a/docs/src/main/asciidoc/funqy-http.adoc
+++ b/docs/src/main/asciidoc/funqy-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding (Standalone)
 

--- a/docs/src/main/asciidoc/funqy-knative-events.adoc
+++ b/docs/src/main/asciidoc/funqy-knative-events.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy Knative Events Binding
 

--- a/docs/src/main/asciidoc/funqy.adoc
+++ b/docs/src/main/asciidoc/funqy.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy
 

--- a/docs/src/main/asciidoc/gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/gcp-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Google Cloud Functions (Serverless) with RESTEasy, Undertow, or Vert.x Web
 :extension-status: experimental

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Google Cloud Functions (Serverless)
 :extension-status: experimental

--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Getting started with Reactive
 

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Testing Your Application
 
@@ -991,8 +991,8 @@ remove duplicates. If you want to only enable a test resource on a single test c
 
 Quarkus provides a few implementations of `QuarkusTestResourceLifecycleManager` out of the box (see `io.quarkus.test.h2.H2DatabaseTestResource` which starts an H2 database, or `io.quarkus.test.kubernetes.client.KubernetesMockServerTestResource` which starts a mock Kubernetes API server),
 but it is common to create custom implementations to address specific application needs.
-Common cases include starting docker containers using https://www.testcontainers.org/[Testcontainers] (an example of which can be found https://github.com/quarkusio/quarkus-quickstarts/blob/master/kafka-quickstart/src/test/java/org/acme/kafka/KafkaResource.java[here]),
-or starting a mock HTTP server using http://wiremock.org/[Wiremock] (an example of which can be found https://github.com/geoand/quarkus-test-demo/blob/master/src/test/java/org/acme/getting/started/country/WiremockCountries.java[here]).
+Common cases include starting docker containers using https://www.testcontainers.org/[Testcontainers] (an example of which can be found https://github.com/quarkusio/quarkus-quickstarts/blob/main/kafka-quickstart/src/test/java/org/acme/kafka/KafkaResource.java[here]),
+or starting a mock HTTP server using http://wiremock.org/[Wiremock] (an example of which can be found https://github.com/geoand/quarkus-test-demo/blob/main/src/test/java/org/acme/getting/started/country/WiremockCountries.java[here]).
 
 === Annotation-based test resources
 

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Creating Your First Application
 

--- a/docs/src/main/asciidoc/gradle-config.adoc
+++ b/docs/src/main/asciidoc/gradle-config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Gradle Plugin Repositories
 

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building Quarkus apps with Gradle
 

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting Started with gRPC
 

--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Consuming a gRPC Service
 

--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Implementing a gRPC Service
 

--- a/docs/src/main/asciidoc/grpc.adoc
+++ b/docs/src/main/asciidoc/grpc.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus gRPC
 

--- a/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Simplified Hibernate ORM with Panache and Kotlin
 

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Simplified Hibernate ORM with Panache
 

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Hibernate ORM and JPA
 

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Hibernate Search guide
 :hibernate-search-doc-prefix: https://docs.jboss.org/hibernate/search/6.0/reference/en-US/html_single/

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - HTTP Reference
 

--- a/docs/src/main/asciidoc/ide-tooling.adoc
+++ b/docs/src/main/asciidoc/ide-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Tools in your favorite IDE
 

--- a/docs/src/main/asciidoc/infinispan-client.adoc
+++ b/docs/src/main/asciidoc/infinispan-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Infinispan Client
 

--- a/docs/src/main/asciidoc/jgit.adoc
+++ b/docs/src/main/asciidoc/jgit.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - JGit
 

--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using JMS
 include::./attributes.adoc[]

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Apache Kafka Streams
 
@@ -52,7 +52,7 @@ Together, these settings will ensure that the application can very quickly recon
 
 In this guide, we are going to generate (random) temperature values in one component (named `generator`).
 These values are associated to given weather stations and are written in a Kafka topic (`temperature-values`).
-Another topic (`weather-stations`) contains just the master data about the weather stations themselves (id and name).
+Another topic (`weather-stations`) contains just the main data about the weather stations themselves (id and name).
 
 A second component (`aggregator`) reads from the two Kafka topics and processes them in a streaming pipeline:
 

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Apache Kafka with Reactive Messaging
 

--- a/docs/src/main/asciidoc/kogito.adoc
+++ b/docs/src/main/asciidoc/kogito.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Kogito to add business automation capabilities to an application
 

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Kotlin
 

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Kubernetes Client
 
@@ -47,7 +47,7 @@ quarkus.kubernetes-client.trust-certs=false
 quarkus.kubernetes-client.namespace=default
 ----
 
-Note that the full list of properties is available in the https://github.com/quarkusio/quarkus/blob/master/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientBuildConfig.java[KubernetesClientBuildConfig] class.
+Note that the full list of properties is available in the https://github.com/quarkusio/quarkus/blob/main/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientBuildConfig.java[KubernetesClientBuildConfig] class.
 
 === Overriding
 

--- a/docs/src/main/asciidoc/kubernetes-config.adoc
+++ b/docs/src/main/asciidoc/kubernetes-config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Kubernetes Config
 

--- a/docs/src/main/asciidoc/lifecycle.adoc
+++ b/docs/src/main/asciidoc/lifecycle.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Application Initialization and Termination
 

--- a/docs/src/main/asciidoc/liquibase.adoc
+++ b/docs/src/main/asciidoc/liquibase.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Liquibase
 

--- a/docs/src/main/asciidoc/logging-sentry.adoc
+++ b/docs/src/main/asciidoc/logging-sentry.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Logging to Sentry
 

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Configuring Logging
 

--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Sending emails
 

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building applications with Maven
 

--- a/docs/src/main/asciidoc/micrometer.adoc
+++ b/docs/src/main/asciidoc/micrometer.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Micrometer Metrics
 

--- a/docs/src/main/asciidoc/microprofile-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/microprofile-fault-tolerance.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Fault Tolerance
 

--- a/docs/src/main/asciidoc/microprofile-graphql.adoc
+++ b/docs/src/main/asciidoc/microprofile-graphql.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - GraphQL
 

--- a/docs/src/main/asciidoc/microprofile-health.adoc
+++ b/docs/src/main/asciidoc/microprofile-health.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - MicroProfile Health
 

--- a/docs/src/main/asciidoc/microprofile-metrics.adoc
+++ b/docs/src/main/asciidoc/microprofile-metrics.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - MicroProfile Metrics
 

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Simplified MongoDB with Panache
 

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the MongoDB Client
 include::./attributes.adoc[]

--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using SSL With Native Executables
 

--- a/docs/src/main/asciidoc/neo4j.adoc
+++ b/docs/src/main/asciidoc/neo4j.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Neo4j
 :neo4j_version: 4.0.0

--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenAPI and Swagger UI
 

--- a/docs/src/main/asciidoc/opentracing.adoc
+++ b/docs/src/main/asciidoc/opentracing.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenTracing
 

--- a/docs/src/main/asciidoc/optaplanner.adoc
+++ b/docs/src/main/asciidoc/optaplanner.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = OptaPlanner - Using AI to optimize a schedule with OptaPlanner
 

--- a/docs/src/main/asciidoc/performance-measure.adoc
+++ b/docs/src/main/asciidoc/performance-measure.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Measuring Performance
 

--- a/docs/src/main/asciidoc/picocli.adoc
+++ b/docs/src/main/asciidoc/picocli.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Command Mode with Picocli
 :extension-status: experimental

--- a/docs/src/main/asciidoc/platform.adoc
+++ b/docs/src/main/asciidoc/platform.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Platform
 

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scheduling Periodic Tasks with Quartz
 

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Qute Reference Guide
 

--- a/docs/src/main/asciidoc/qute.adoc
+++ b/docs/src/main/asciidoc/qute.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Qute Templating Engine
 

--- a/docs/src/main/asciidoc/reactive-event-bus.adoc
+++ b/docs/src/main/asciidoc/reactive-event-bus.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the event bus
 

--- a/docs/src/main/asciidoc/reactive-messaging-http.adoc
+++ b/docs/src/main/asciidoc/reactive-messaging-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HTTP and WebSockets with Reactive Messaging
 

--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Reactive Routes
 

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Reactive SQL Clients
 

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the Redis Client
 :extension-status: preview

--- a/docs/src/main/asciidoc/rest-client-multipart.adoc
+++ b/docs/src/main/asciidoc/rest-client-multipart.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the REST Client with Multipart
 

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the REST Client
 

--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Generating JAX-RS resources with Panache
 

--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Writing JSON REST Services
 

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Writing REST Services with RESTEasy Reactive
 

--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scheduler Reference Guide
 

--- a/docs/src/main/asciidoc/scheduler.adoc
+++ b/docs/src/main/asciidoc/scheduler.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scheduling Periodic Tasks
 

--- a/docs/src/main/asciidoc/scripting.adoc
+++ b/docs/src/main/asciidoc/scripting.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scripting with Quarkus
 include::./attributes.adoc[]

--- a/docs/src/main/asciidoc/security-authorization.adoc
+++ b/docs/src/main/asciidoc/security-authorization.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Authorization of Web Endpoints
 

--- a/docs/src/main/asciidoc/security-built-in-authentication.adoc
+++ b/docs/src/main/asciidoc/security-built-in-authentication.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Built-In Authentication Support
 

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Security Tips and Tricks
 

--- a/docs/src/main/asciidoc/security-jdbc.adoc
+++ b/docs/src/main/asciidoc/security-jdbc.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with JDBC
 

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with JPA
 

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using JWT RBAC
 

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect and Keycloak to Centralize Authorization
 

--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with an LDAP Realm
 

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OAuth2 RBAC
 

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect and OAuth2 Client and Filters to manage access tokens
 

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect Multi-Tenancy
 

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect to Protect Web Applications using Authorization Code Flow.
 

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect to Protect Service Applications using Bearer Token Authorization
 

--- a/docs/src/main/asciidoc/security-properties.adoc
+++ b/docs/src/main/asciidoc/security-properties.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with .properties File
 

--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Security Testing
 

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Security Architecture and Guides
 

--- a/docs/src/main/asciidoc/software-transactional-memory.adoc
+++ b/docs/src/main/asciidoc/software-transactional-memory.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Software Transactional Memory in Quarkus
 

--- a/docs/src/main/asciidoc/spring-boot-properties.adoc
+++ b/docs/src/main/asciidoc/spring-boot-properties.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Accessing application properties with Spring Boot properties API
 

--- a/docs/src/main/asciidoc/spring-cache.adoc
+++ b/docs/src/main/asciidoc/spring-cache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Cache API
 

--- a/docs/src/main/asciidoc/spring-cloud-config-client.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Reading properties from Spring Cloud Config Server
 

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Extension for Spring Data API
 
@@ -596,7 +596,7 @@ quarkus.hibernate-orm.implicit-naming-strategy=org.springframework.boot.orm.jpa.
 
 ==== More examples
 
-An extensive list of examples can be seen in the https://github.com/quarkusio/quarkus/tree/master/integration-tests/spring-data-jpa[integration tests] directory which is located inside the Quarkus source code.
+An extensive list of examples can be seen in the https://github.com/quarkusio/quarkus/tree/main/integration-tests/spring-data-jpa[integration tests] directory which is located inside the Quarkus source code.
 
 === What is currently unsupported
 

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Extension for Spring Data REST
 

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring DI API
 

--- a/docs/src/main/asciidoc/spring-scheduled.adoc
+++ b/docs/src/main/asciidoc/spring-scheduled.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Scheduling API
 

--- a/docs/src/main/asciidoc/spring-security.adoc
+++ b/docs/src/main/asciidoc/spring-security.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Security API
 

--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Web API
 

--- a/docs/src/main/asciidoc/tests-with-coverage.adoc
+++ b/docs/src/main/asciidoc/tests-with-coverage.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Measuring the coverage of your tests
 

--- a/docs/src/main/asciidoc/tika.adoc
+++ b/docs/src/main/asciidoc/tika.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Apache Tika
 

--- a/docs/src/main/asciidoc/tooling.adoc
+++ b/docs/src/main/asciidoc/tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using our Tooling
 

--- a/docs/src/main/asciidoc/transaction.adoc
+++ b/docs/src/main/asciidoc/transaction.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Transactions in Quarkus
 

--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Validation with Hibernate Validator
 

--- a/docs/src/main/asciidoc/vault-auth.adoc
+++ b/docs/src/main/asciidoc/vault-auth.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Working with HashiCorp Vault’s Authentication
 

--- a/docs/src/main/asciidoc/vault-datasource.adoc
+++ b/docs/src/main/asciidoc/vault-datasource.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HashiCorp Vault with Databases
 

--- a/docs/src/main/asciidoc/vault-transit.adoc
+++ b/docs/src/main/asciidoc/vault-transit.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HashiCorp Vault's Transit Secret Engine
 

--- a/docs/src/main/asciidoc/vault.adoc
+++ b/docs/src/main/asciidoc/vault.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HashiCorp Vault
 

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Eclipse Vert.x
 

--- a/docs/src/main/asciidoc/websockets.adoc
+++ b/docs/src/main/asciidoc/websockets.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using WebSockets
 

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Writing Your Own Extension
 
@@ -2067,7 +2067,7 @@ Indicates that all charsets should be enabled in native image.
 
 `io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem`::
 A convenient way to tell Quarkus that the extension requires SSL and it should be enabled during native image build.
-When using this feature, remember to add your extension to the list of extensions that offer SSL support automatically on the https://github.com/quarkusio/quarkus/blob/master/docs/src/main/asciidoc/native-and-ssl.adoc[native and ssl guide].
+When using this feature, remember to add your extension to the list of extensions that offer SSL support automatically on the https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/native-and-ssl.adoc[native and ssl guide].
 
 === IDE support tips
 

--- a/docs/src/main/asciidoc/writing-native-applications-tips.adoc
+++ b/docs/src/main/asciidoc/writing-native-applications-tips.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Tips for writing native applications
 

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/KafkaRuntimeConfigProducer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/KafkaRuntimeConfigProducer.java
@@ -2,20 +2,17 @@ package io.quarkus.kafka.client.runtime;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.StreamSupport;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.runtime.ApplicationConfig;
 
-@Dependent
+@Singleton
 public class KafkaRuntimeConfigProducer {
 
     // not "kafka.", because we also inspect env vars, which start with "KAFKA_"
@@ -25,29 +22,27 @@ public class KafkaRuntimeConfigProducer {
 
     @Produces
     @DefaultBean
-    @ApplicationScoped
+    @Singleton
     @Named("default-kafka-broker")
-    public Map<String, Object> createKafkaRuntimeConfig(ApplicationConfig app) {
-        Map<String, Object> properties = new HashMap<>();
-        final Config config = ConfigProvider.getConfig();
+    public Map<String, Object> createKafkaRuntimeConfig(Config config, ApplicationConfig app) {
+        Map<String, Object> result = new HashMap<>();
 
-        StreamSupport
-                .stream(config.getPropertyNames().spliterator(), false)
-                .map(String::toLowerCase)
-                .filter(name -> name.startsWith(CONFIG_PREFIX))
-                .distinct()
-                .sorted()
-                .forEach(name -> {
-                    final String key = name.substring(CONFIG_PREFIX.length() + 1).toLowerCase().replaceAll("[^a-z0-9.]", ".");
-                    final String value = config.getOptionalValue(name, String.class).orElse("");
-                    properties.put(key, value);
-                });
-
-        if (!properties.containsKey(GROUP_ID) && app.name.isPresent()) {
-            properties.put(GROUP_ID, app.name.get());
+        for (String propertyName : config.getPropertyNames()) {
+            String propertyNameLowerCase = propertyName.toLowerCase();
+            if (!propertyNameLowerCase.startsWith(CONFIG_PREFIX)) {
+                continue;
+            }
+            String effectivePropertyName = propertyNameLowerCase.substring(CONFIG_PREFIX.length() + 1).toLowerCase()
+                    .replaceAll("[^a-z0-9.]", ".");
+            String value = config.getOptionalValue(propertyName, String.class).orElse("");
+            result.put(effectivePropertyName, value);
         }
 
-        return properties;
+        if (!result.containsKey(GROUP_ID) && app.name.isPresent()) {
+            result.put(GROUP_ID, app.name.get());
+        }
+
+        return result;
     }
 
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PrometheusConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PrometheusConfig.java
@@ -13,7 +13,7 @@ public class PrometheusConfig {
     // Removal of prometheus.io from example:
     // https://github.com/prometheus/prometheus/commit/03a9e7f72e072c6d29f422425d8acd91a957836b
     // Current example of relabeling using non-prometheus.io-based strings:
-    // https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml#L139
+    // https://github.com/prometheus/prometheus/blob/main/documentation/examples/prometheus-kubernetes.yml#L139
 
     /**
      * When true (the default), emit a set of annotations to identify
@@ -32,7 +32,7 @@ public class PrometheusConfig {
      * knock-on effects. The default value is {@code prometheus.io}
      *
      * See Prometheus example:
-     * https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml
+     * https://github.com/prometheus/prometheus/blob/main/documentation/examples/prometheus-kubernetes.yml
      */
     @ConfigItem(defaultValue = "prometheus.io")
     String prefix;

--- a/extensions/tika/runtime/src/main/java/io/quarkus/tika/TikaContent.java
+++ b/extensions/tika/runtime/src/main/java/io/quarkus/tika/TikaContent.java
@@ -43,7 +43,7 @@ public class TikaContent {
      * Return the content of the embedded documents
      *
      * @return the list of the embedded documents, will be empty
-     *         if the current document has no embedded content or it has been appended to the master content
+     *         if the current document has no embedded content or it has been appended to the main content
      */
     public List<TikaContent> getEmbeddedContent() {
         return embeddedContent;

--- a/extensions/tika/runtime/src/main/java/io/quarkus/tika/TikaParser.java
+++ b/extensions/tika/runtime/src/main/java/io/quarkus/tika/TikaParser.java
@@ -84,15 +84,15 @@ public class TikaParser {
             try (InputStream tikaStream = TikaInputStream.get(entityStream)) {
                 parser.parse(tikaStream, tikaHandler, tikaMetadata, context);
                 if (this.appendEmbeddedContent) {
-                    // the embedded content if any has already been appended to the master content
+                    // the embedded content if any has already been appended to the main document content
                     return new TikaContent(tikaHandler == null ? null : tikaHandler.toString().trim(), convert(tikaMetadata));
                 } else {
                     RecursiveParserWrapperHandler rHandler = (RecursiveParserWrapperHandler) tikaHandler;
 
-                    // The metadata list represents the master and embedded content (text and metadata)
-                    // The first metadata in the list represents the master (outer) content
+                    // The metadata list represents the main document and embedded content (text and metadata)
+                    // The first metadata in the list represents the main document (outer) content
                     List<org.apache.tika.metadata.Metadata> allMetadata = rHandler.getMetadataList();
-                    String masterText = allMetadata.get(0).get(AbstractRecursiveParserWrapperHandler.TIKA_CONTENT);
+                    String mainDocumentText = allMetadata.get(0).get(AbstractRecursiveParserWrapperHandler.TIKA_CONTENT);
 
                     // Embedded (inner) content starts from the index 1.
                     List<TikaContent> embeddedContent = new LinkedList<>();
@@ -104,7 +104,7 @@ public class TikaParser {
                             embeddedContent.add(new TikaContent(embeddedText.trim(), convert(allMetadata.get(i))));
                         }
                     }
-                    return new TikaContent(masterText, convert(allMetadata.get(0)), embeddedContent);
+                    return new TikaContent(mainDocumentText, convert(allMetadata.get(0)), embeddedContent);
 
                 }
             }
@@ -118,14 +118,14 @@ public class TikaParser {
     private ContentHandler validateContentHandler(ContentHandler contentHandler) {
         if (!this.appendEmbeddedContent && !(contentHandler instanceof RecursiveParserWrapperHandler)) {
             throw new IllegalStateException(
-                    "The master and every embedded document will require a unique ContentHandler instance");
+                    "The main document and every embedded document will require a unique ContentHandler instance");
         }
         return contentHandler;
     }
 
     private ContentHandler createContentHandler() {
         // RecursiveParserWrapperHandler will use the factory to create a new ContentHandler
-        // for the master and each of the embedded documents
+        // for the main document and each of the embedded documents
         return this.appendEmbeddedContent ? new ToTextContentHandler()
                 : new RecursiveParserWrapperHandler(
                         new BasicContentHandlerFactory(BasicContentHandlerFactory.HANDLER_TYPE.TEXT, -1));

--- a/extensions/tika/runtime/src/main/java/io/quarkus/tika/runtime/TikaConfiguration.java
+++ b/extensions/tika/runtime/src/main/java/io/quarkus/tika/runtime/TikaConfiguration.java
@@ -67,7 +67,7 @@ public class TikaConfiguration {
 
     /**
      * Controls how the content of the embedded documents is parsed.
-     * By default it is appended to the master document content.
+     * By default it is appended to the main document content.
      * Setting this property to false makes the content of each of the embedded documents
      * available separately.
      */

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/StaticResourcesHotReplacementSetup.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/StaticResourcesHotReplacementSetup.java
@@ -14,11 +14,9 @@ public class StaticResourcesHotReplacementSetup implements HotReplacementSetup {
     @Override
     public void setupHotDeployment(HotReplacementContext context) {
         List<Path> resources = new ArrayList<>();
+        addPathIfContainsStaticResources(resources, context.getClassesDir());
         for (Path resourceDir : context.getResourcesDir()) {
-            Path resource = resourceDir.resolve(StaticResourcesRecorder.META_INF_RESOURCES);
-            if (Files.exists(resource)) {
-                resources.add(resource);
-            }
+            addPathIfContainsStaticResources(resources, resourceDir);
         }
         StaticResourcesRecorder.setHotDeploymentResources(resources);
     }
@@ -31,4 +29,12 @@ public class StaticResourcesHotReplacementSetup implements HotReplacementSetup {
     public void close() {
         StaticResourcesRecorder.setHotDeploymentResources(null);
     }
+
+    private void addPathIfContainsStaticResources(List<Path> resources, Path resourceDir) {
+        Path resource = resourceDir.resolve(StaticResourcesRecorder.META_INF_RESOURCES);
+        if (Files.exists(resource)) {
+            resources.add(resource);
+        }
+    }
+
 }

--- a/extensions/websockets/deployment/src/main/java/io/quarkus/undertow/websockets/deployment/WebsocketProcessor.java
+++ b/extensions/websockets/deployment/src/main/java/io/quarkus/undertow/websockets/deployment/WebsocketProcessor.java
@@ -37,12 +37,12 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.netty.deployment.EventLoopSupplierBuildItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
-import io.quarkus.undertow.websockets.runtime.UndertowWebsocketRecorder;
+import io.quarkus.undertow.websockets.runtime.WebsocketRecorder;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.undertow.websockets.DefaultContainerConfigurator;
 import io.undertow.websockets.UndertowContainerProvider;
 
-public class UndertowWebsocketProcessor {
+public class WebsocketProcessor {
 
     private static final DotName SERVER_ENDPOINT = DotName.createSimple(ServerEndpoint.class.getName());
     private static final DotName CLIENT_ENDPOINT = DotName.createSimple(ClientEndpoint.class.getName());
@@ -91,7 +91,7 @@ public class UndertowWebsocketProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     public FilterBuildItem deploy(final CombinedIndexBuildItem indexBuildItem,
-            UndertowWebsocketRecorder recorder,
+            WebsocketRecorder recorder,
             BuildProducer<ReflectiveClassBuildItem> reflection,
             EventLoopSupplierBuildItem eventLoopSupplierBuildItem,
             List<AnnotatedWebsocketEndpointBuildItem> annotatedEndpoints,
@@ -165,7 +165,7 @@ public class UndertowWebsocketProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    ServiceStartBuildItem setupWorker(UndertowWebsocketRecorder recorder, ExecutorBuildItem exec) {
+    ServiceStartBuildItem setupWorker(WebsocketRecorder recorder, ExecutorBuildItem exec) {
         recorder.setupWorker(exec.getExecutorProxy());
         return new ServiceStartBuildItem("Websockets");
     }

--- a/extensions/websockets/runtime/src/main/java/io/quarkus/undertow/websockets/runtime/WebsocketRecorder.java
+++ b/extensions/websockets/runtime/src/main/java/io/quarkus/undertow/websockets/runtime/WebsocketRecorder.java
@@ -30,9 +30,9 @@ import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
 @Recorder
-public class UndertowWebsocketRecorder {
+public class WebsocketRecorder {
 
-    private static final Logger log = Logger.getLogger(UndertowWebsocketRecorder.class);
+    private static final Logger log = Logger.getLogger(WebsocketRecorder.class);
 
     public void setupWorker(Executor executor) {
         ExecutorSupplier.executor = executor;
@@ -62,7 +62,7 @@ public class UndertowWebsocketRecorder {
                 log.error("Could not initialize websocket class " + i, e);
             }
         }
-        Set<Class<?>> newAnnotatatedEndpoints = new HashSet<>();
+        Set<Class<?>> newAnnotatedEndpoints = new HashSet<>();
         Set<ServerEndpointConfig> serverEndpointConfigurations = new HashSet<>();
 
         final Set<ServerApplicationConfig> configInstances = new HashSet<>();
@@ -79,7 +79,7 @@ public class UndertowWebsocketRecorder {
             for (ServerApplicationConfig config : configInstances) {
                 Set<Class<?>> returnedEndpoints = config.getAnnotatedEndpointClasses(allScannedAnnotatedEndpoints);
                 if (returnedEndpoints != null) {
-                    newAnnotatatedEndpoints.addAll(returnedEndpoints);
+                    newAnnotatedEndpoints.addAll(returnedEndpoints);
                 }
                 Set<ServerEndpointConfig> endpointConfigs = config.getEndpointConfigs(allScannedEndpointImplementations);
                 if (endpointConfigs != null) {
@@ -87,11 +87,11 @@ public class UndertowWebsocketRecorder {
                 }
             }
         } else {
-            newAnnotatatedEndpoints.addAll(allScannedAnnotatedEndpoints);
+            newAnnotatedEndpoints.addAll(allScannedAnnotatedEndpoints);
         }
 
         //annotated endpoints first
-        for (Class<?> endpoint : newAnnotatatedEndpoints) {
+        for (Class<?> endpoint : newAnnotatedEndpoints) {
             if (endpoint != null) {
                 container.addEndpoint(endpoint);
             }

--- a/independent-projects/tools/codestarts/README.adoc
+++ b/independent-projects/tools/codestarts/README.adoc
@@ -59,8 +59,8 @@ Each codestart consists of:
 
 == Where are the Quarkus Extension Codestarts located
 
-* Quarkus core codestarts dir: https://github.com/quarkusio/quarkus/tree/master/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core
-* Extension codestarts directory: https://github.com/quarkusio/quarkus/tree/master/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/examples
+* Quarkus core codestarts dir: https://github.com/quarkusio/quarkus/tree/main/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core
+* Extension codestarts directory: https://github.com/quarkusio/quarkus/tree/main/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/examples
 
 == Writing an Extension Codestart
 
@@ -89,7 +89,7 @@ jbang qcd@quarkusio -l java,kotlin -c ./examples/quarkus my-example
 . put the working extension codestart in `devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/examples` and submit a PR.
 . Add the `ref` value of the codestart to the extension metadata. This is how it is activated when the extension is selected (e.g )
 
-    Example: https://github.com/quarkusio/quarkus/blob/master/extensions/resteasy/runtime/src/main/resources/META-INF/quarkus-extension.yaml#L14
+    Example: https://github.com/quarkusio/quarkus/blob/main/extensions/resteasy/runtime/src/main/resources/META-INF/quarkus-extension.yaml#L14
 
 *NOTE* This is temporary, extension codestarts will soon live alongside the extension.
 
@@ -97,10 +97,10 @@ jbang qcd@quarkusio -l java,kotlin -c ./examples/quarkus my-example
 
 * We already have tests making sure we can create and build apps with all extension codestarts together with each build tools and languages:
 +
-https://github.com/quarkusio/quarkus/blob/master/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartRunIT.java#L74-L90
+https://github.com/quarkusio/quarkus/blob/main/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartRunIT.java#L74-L90
 * We have specific tests making sure the generation is working as expected (we will split it soon, you may create another class for your codestart):
 +
-https://github.com/quarkusio/quarkus/blob/master/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+https://github.com/quarkusio/quarkus/blob/main/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
 
 === Writing tips
 
@@ -213,7 +213,7 @@ This is a big constraint and should be done as a last resort:
 
 To make it a singleton:
 
-* Put it in this directory: https://github.com/quarkusio/quarkus/tree/master/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/singleton-examples
+* Put it in this directory: https://github.com/quarkusio/quarkus/tree/main/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/singleton-examples
 * Add `singleton-example` in the tags:
 +
 codestart.yml
@@ -228,8 +228,8 @@ tags:
 
 == The generator sources
 
-* Codestart generator: https://github.com/quarkusio/quarkus/tree/master/independent-projects/tools/codestarts
-* Quarkus implementation of the Codestart generator: https://github.com/quarkusio/quarkus/tree/master/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus
+* Codestart generator: https://github.com/quarkusio/quarkus/tree/main/independent-projects/tools/codestarts
+* Quarkus implementation of the Codestart generator: https://github.com/quarkusio/quarkus/tree/main/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus
 
 == Issues and Feature requests
 

--- a/independent-projects/tools/codestarts/examples/quarkus/my-example/codestart.yml
+++ b/independent-projects/tools/codestarts/examples/quarkus/my-example/codestart.yml
@@ -5,7 +5,7 @@ tags: example
 metadata:
   title: My Hello Codestart example
   description: This is an example Hello Quarkus codestart, it contains the base of a Quarkus extension codestart.
-  related-guide-section: https://github.com/quarkusio/quarkus/blob/master/independent-projects/tools/codestarts/README.adoc
+  related-guide-section: https://github.com/quarkusio/quarkus/blob/main/independent-projects/tools/codestarts/README.adoc
   path: /my-hello-example
 language:
   base:

--- a/independent-projects/tools/devtools-common/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/build.yml
+++ b/independent-projects/tools/devtools-common/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - "master"
+      - "main"
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'

--- a/independent-projects/tools/devtools-common/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/quarkus-snapshot.tpl.qute.yaml
+++ b/independent-projects/tools/devtools-common/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/quarkus-snapshot.tpl.qute.yaml
@@ -38,13 +38,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: current-repo
-          ref: master
+          ref: main
 
       - name: Checkout Ecosystem
         uses: actions/checkout@v2
         with:
           repository: ${{ env.ECOSYSTEM_CI_REPO }}
-          ref: master
+          ref: main
           path: ecosystem-ci
 
       - name: Setup and Run Tests

--- a/independent-projects/tools/devtools-common/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/README.tpl.qute.md
+++ b/independent-projects/tools/devtools-common/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/README.tpl.qute.md
@@ -20,4 +20,4 @@ The documentation for this extension should be maintained as part of this reposi
 
 The layout should follow the [Antora's Standard File and Directory Set](https://docs.antora.org/antora/2.3/standard-directories/).
 
-Once the docs are ready to be published, please open a PR including this repository in the [Quarkiverse Docs Antora playbook](https://github.com/quarkiverse/quarkiverse-docs/blob/master/antora-playbook.yml#L7). See an example [here](https://github.com/quarkiverse/quarkiverse-docs/pull/1).
+Once the docs are ready to be published, please open a PR including this repository in the [Quarkiverse Docs Antora playbook](https://github.com/quarkiverse/quarkiverse-docs/blob/main/antora-playbook.yml#L7). See an example [here](https://github.com/quarkiverse/quarkiverse-docs/pull/1).

--- a/integration-tests/devtools/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateGradleNoWrapperGithubAction/.github_workflows_ci.yml
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateGradleNoWrapperGithubAction/.github_workflows_ci.yml
@@ -4,9 +4,9 @@ name: Quarkus Codestart CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/integration-tests/devtools/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateGradleWrapperGithubAction/.github_workflows_ci.yml
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateGradleWrapperGithubAction/.github_workflows_ci.yml
@@ -4,9 +4,9 @@ name: Quarkus Codestart CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Pods.java
+++ b/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Pods.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.kubernetes.client;
 
 import java.util.List;
+import java.util.UUID;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -65,7 +66,8 @@ public class Pods {
     public Response createNew(@PathParam("namespace") String namespace) {
         return Response
                 .ok(kubernetesClient.pods().inNamespace(namespace)
-                        .create(new PodBuilder().withNewMetadata().withResourceVersion("12345")
+                        .create(new PodBuilder().withNewMetadata()
+                                .withName(UUID.randomUUID().toString()).withResourceVersion("12345")
                                 .endMetadata().build()))
                 .build();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -237,8 +237,8 @@
                 </property>
             </activation>
             <properties>
-                <!-- the *local* master, not refs/remotes/... -->
-                <gib.referenceBranch>master</gib.referenceBranch>
+                <!-- the *local* main, not refs/remotes/... -->
+                <gib.referenceBranch>main</gib.referenceBranch>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
The original resources without Maven properties resolution were provided by
Static Handler for `src/main/resources/META-INF/resources` files when running
in dev mode. The strategy used for hot deployment doesn't consider the resources
filtering. So the interpolation of Maven properties wasn't processed.